### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/lang.ts
+++ b/lang.ts
@@ -41,8 +41,8 @@ export const en = {
         verify: "You have successfully verified. You may go back to Discord.",
         verifyBot: "You have successfully verified. Enjoy the server!",
         linkgen: (link:string)=>{ // functions are used for string templates, instead of just using .replace a bunch
-            let hn = new URL(link || "http://unknown.link").hostname;
-            let allowedHosts = ["artemis-bot.com", "www.artemis-bot.com"];
+            // let hn = new URL(link || "http://test[.]com").hostname;
+            // let allowedHosts = ["test[.]com", "www[.]test[.]com"];
             let isOfficialLink = allowedHosts.includes(hn);
             return `**This server is protected by Artemis, a FOSS server protection bot. You must verify to continue.** Don't worry, this is 100% automatic.\n\n[Click here to verify! (\`${hn}\`${isOfficialLink ? ", official Artemis link!" : ""})](${link})`
         },

--- a/lang.ts
+++ b/lang.ts
@@ -41,8 +41,10 @@ export const en = {
         verify: "You have successfully verified. You may go back to Discord.",
         verifyBot: "You have successfully verified. Enjoy the server!",
         linkgen: (link:string)=>{ // functions are used for string templates, instead of just using .replace a bunch
-            let hn = new URL(link || "http://unknown.link").hostname
-            return `**This server is protected by Artemis, a FOSS server protection bot. You must verify to continue.** Don't worry, this is 100% automatic.\n\n[Click here to verify! (\`${hn}\`${hn.endsWith("artemis-bot.com") ? ", official Artemis link!" : ""})](${link})`
+            let hn = new URL(link || "http://unknown.link").hostname;
+            let allowedHosts = ["artemis-bot.com", "www.artemis-bot.com"];
+            let isOfficialLink = allowedHosts.includes(hn);
+            return `**This server is protected by Artemis, a FOSS server protection bot. You must verify to continue.** Don't worry, this is 100% automatic.\n\n[Click here to verify! (\`${hn}\`${isOfficialLink ? ", official Artemis link!" : ""})](${link})`
         },
         updatedconf: "Server configuration has been updated successfully.",
         auto: "You have verified.",


### PR DESCRIPTION
Potential fix for [https://github.com/WhyDRS/Artemis-v2/security/code-scanning/1](https://github.com/WhyDRS/Artemis-v2/security/code-scanning/1)

To fix the problem, we need to replace the `endsWith` check with a more secure approach that uses a whitelist of allowed hosts. This involves parsing the URL and checking if the hostname is in the list of allowed hosts.

1. Define a whitelist of allowed hosts.
2. Parse the URL to extract the hostname.
3. Check if the hostname is in the whitelist.
4. Update the message accordingly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
